### PR TITLE
fix: Open in Github link

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -20,8 +20,8 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
   const MDX = page.data.body;
   const neighbours = findNeighbour(source.pageTree, page.url);
   const gitConfig = {
-    user: "username",
-    repo: "repo",
+    user: "TheOrcDev",
+    repo: "warcraftcn-ui",
     branch: "main",
   };
 
@@ -43,7 +43,7 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
         <div className="mb-6 flex flex-row items-center gap-2 border-b py-4">
           <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
           <ViewOptions
-            githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/docs/content/docs/${page.path}`}
+            githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
             markdownUrl={`${page.url}.mdx`}
           />
         </div>


### PR DESCRIPTION
Just a small fix 😄 

The Open in github button was not working properly.
- Wrong path (extra '/docs')
- Wrong gitConfig for git user and repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GitHub source links in documentation so they point to the actual content files (fixed path mapping).

* **Chores**
  * Replaced placeholder repository configuration values with actual repository details to ensure links and metadata resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->