### PR TITLE
fix: added dropdown menu to registry.json, main file was missing

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -147,6 +147,11 @@
       "registryDependencies": ["dropdown-menu"],
       "files": [
         {
+          "path": "components/ui/warcraftcn/dropdown-menu.tsx",
+          "type": "registry:component",
+          "target": "components/ui/warcraftcn/dropdown-menu.tsx"
+        },
+        {
           "path": "components/ui/warcraftcn/styles/warcraft.css",
           "type": "registry:component",
           "target": "components/ui/warcraftcn/styles/warcraft.css"


### PR DESCRIPTION
I wanted to import the dropdown on my project and the dropdown-menu from the warcraftcn library wasn't imported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warcraft Dropdown Menu component is now available in the UI components library, providing an additional dropdown menu option with Warcraft styling for use in your applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->